### PR TITLE
Suggestions for Dynamic Transforms

### DIFF
--- a/GameData/KCS/Patches/Misc.cfg
+++ b/GameData/KCS/Patches/Misc.cfg
@@ -145,17 +145,3 @@
         seperatorType = port
   	}
 }
-
-//modify any command pod to have the dynamic control point
-@PART[*]:HAS[@MODULE[ModuleCommand]] 
-{
-  	%MODULE[ModuleCommand]
- 	{
-		CONTROLPOINT
-		{
-			name = dynamic
-			displayName = Dynamic
-			orientation = 0,0,0
-		}
-  	}
-}

--- a/Source/KerbalCombatSystems/DecouplerDesignator.cs
+++ b/Source/KerbalCombatSystems/DecouplerDesignator.cs
@@ -17,7 +17,7 @@ namespace KerbalCombatSystems
             isPersistant = true,
             guiActive = true,
             guiActiveEditor = true,
-            guiName = "Seperator Type",
+            guiName = "Separator Type",
             groupName = DecouplerDesignationGroupName,
             groupDisplayName = DecouplerDesignationGroupName),
             UI_ChooseOption(controlEnabled = true, affectSymCounterparts = UI_Scene.None,
@@ -35,7 +35,10 @@ namespace KerbalCombatSystems
                     part.GetComponent<ModuleDecouple>().Decouple();
                     break;
                 case "port":
-                    part.GetComponent<ModuleDockingNode>().Undock();
+                    ModuleDockingNode node = part.GetComponent<ModuleDockingNode>();
+                    if (node.state != "Ready") // Undocking a free docking port throws an error.
+                        node.Undock();
+
                     break;
                 default:
                     Debug.Log("[KCS]: Improper Decoupler Designation");

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -34,6 +34,7 @@ namespace KerbalCombatSystems
         public float maxAcceleration;
         private Vector3 rcs;
         private float targetSize;
+        private Vector3 propulsionVector;
 
         // Components
 
@@ -41,7 +42,6 @@ namespace KerbalCombatSystems
         private ModuleDecouplerDesignate seperator;
         private ModuleWeaponController controller;
         private List<ModuleEngines> engines;
-        private List<ModuleRCSFX> rcsList;
         private ModuleEngines mainEngine;
         private Part mainEnginePart;
         private int partCount = -1;
@@ -96,14 +96,18 @@ namespace KerbalCombatSystems
             fc.RCSPower = 20;
             fc.Drive();
 
-            //get and enable rcs thrusters
-            rcsList = vessel.FindPartModulesImplementing<ModuleRCSFX>();
-            rcsList.ForEach(t => t.rcsEnabled = true);
+            // Get and enable RCS thrusters.
+            List<ModuleRCSFX> rcsThrusters = vessel.FindPartModulesImplementing<ModuleRCSFX>();
+            rcsThrusters.ForEach(t => t.rcsEnabled = true);
 
-            //get probe core and modify it's reference transform
+            // Get a probe core and align its reference transform with the propulsion vector.
             ModuleCommand commander = FindCommand(vessel);
-            AlignReference(commander, -GetFireVector(engines, rcsList, commander.transform.position));
+            propulsionVector = -GetFireVector(commander.transform.position, engines, rcsThrusters);
+            AlignReference(commander, propulsionVector);
             commander.MakeReference();
+
+            // Store the propulsion vector for debugging.
+            propulsionVector = vessel.transform.InverseTransformDirection(propulsionVector);
 
             fc.attitude = vessel.ReferenceTransform.up;
 
@@ -315,7 +319,7 @@ namespace KerbalCombatSystems
             {
                 Vector3 origin = vessel.CoM;
                 KCSDebug.PlotLine(new[] { origin, origin + (relVelNrm * 15) }, rvLine);
-                KCSDebug.PlotLine(new Vector3[] { origin, origin + (GetFireVector(engines, rcsList, origin) * -1) }, thrustLine);
+                KCSDebug.PlotLine(new Vector3[] { origin, origin + vessel.transform.TransformDirection(propulsionVector)}, thrustLine);
 
 
                 if (isInterceptor)

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -54,7 +54,7 @@ namespace KerbalCombatSystems
         private IEnumerator Launch()
         {
             // find decoupler
-            seperator = FindDecoupler(part, "Default");
+            seperator = FindDecoupler(part);
 
             bool frontLaunch = Vector3.Dot(seperator.transform.up, vessel.ReferenceTransform.up) > 0.99;
             controller.frontLaunch = frontLaunch;
@@ -207,7 +207,7 @@ namespace KerbalCombatSystems
             fc.alignmentToleranceforBurn = previousTolerance;
 
             // Remove end cap. todo: will need to change to support cluster missiles.
-            List<ModuleDecouplerDesignate> decouplers = FindDecouplerChildren(vessel.rootPart, "Default");
+            List<ModuleDecouplerDesignate> decouplers = FindDecouplerChildren(vessel.rootPart);
             decouplers.ForEach(d => d.Separate());
 
             List<ModuleProceduralFairing> fairings = vessel.FindPartModulesImplementing<ModuleProceduralFairing>();

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -321,7 +321,6 @@ namespace KerbalCombatSystems
                 KCSDebug.PlotLine(new[] { origin, origin + (relVelNrm * 15) }, rvLine);
                 KCSDebug.PlotLine(new Vector3[] { origin, origin + vessel.transform.TransformDirection(propulsionVector)}, thrustLine);
 
-
                 if (isInterceptor)
                     KCSDebug.PlotLine(new[] { origin, origin + targetVector }, interceptLine);
                 else

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -98,7 +98,7 @@ namespace KerbalCombatSystems
             fc.Drive();
 
             // Get and enable RCS thrusters.
-            List<ModuleRCSFX> rcsThrusters = vessel.FindPartModulesImplementing<ModuleRCSFX>();
+            rcsThrusters = vessel.FindPartModulesImplementing<ModuleRCSFX>();
             rcsThrusters.ForEach(t => t.rcsEnabled = true);
 
             // Get a probe core and align its reference transform with the propulsion vector.

--- a/Source/KerbalCombatSystems/MissileGuidance.cs
+++ b/Source/KerbalCombatSystems/MissileGuidance.cs
@@ -41,6 +41,7 @@ namespace KerbalCombatSystems
         private KCSFlightController fc;
         private ModuleDecouplerDesignate seperator;
         private ModuleWeaponController controller;
+        private List<ModuleRCSFX> rcsThrusters;
         private List<ModuleEngines> engines;
         private ModuleEngines mainEngine;
         private Part mainEnginePart;

--- a/Source/KerbalCombatSystems/RocketTargeting.cs
+++ b/Source/KerbalCombatSystems/RocketTargeting.cs
@@ -137,15 +137,15 @@ namespace KerbalCombatSystems
 
             // Find the engines.
             var engines = new List<ModuleEngines>();
-            var thrusters = new List<ModuleRCSFX>(); //list isn't used in rockets but the util requires it
             ModuleEngines eng;
 
             foreach (var p in rocketParts)
             {
                 eng = p.FindModuleImplementing<ModuleEngines>();
+                if (eng == null)
+                    continue;
 
-                if (eng == null) continue;
-                    engines.Add(eng);
+                engines.Add(eng);
 
                 // Measure total fuel consumption in tons per second.
                 consumptionRate += Mathf.Lerp(eng.minFuelFlow, eng.maxFuelFlow, 1 * 0.01f * eng.thrustPercentage) * eng.flowMultiplier; // throttle = 1
@@ -154,7 +154,7 @@ namespace KerbalCombatSystems
             if (engines.Count < 1)
                 return -1;
 
-            Vector3 thrustVector = GetFireVector(engines, thrusters, origin) * -1;
+            Vector3 thrustVector = GetFireVector(origin, engines) * -1;
             aimVector = thrustVector.normalized;
 
             float thrust = Vector3.Dot(thrustVector, decoupler.transform.up);
@@ -267,8 +267,6 @@ namespace KerbalCombatSystems
             controller.aimPart = decoupler.part;
         }
 
-        
-
         public void OnDestroy() =>
             KCSDebug.DestroyLine(leadLine);
 
@@ -278,7 +276,7 @@ namespace KerbalCombatSystems
             var mr = prediction.GetComponent<MeshRenderer>();
 
             Material sphereMat = new Material(Shader.Find("Unlit/Color"));
-            sphereMat.color = new Color(1f, 0f, 1f, 0.4f);//was hoping this would come up opaque tbh
+            sphereMat.color = new Color(1f, 0f, 1f, 0.4f);
             mr.material = sphereMat;
 
             //todo sphere doesn't destroy

--- a/Source/KerbalCombatSystems/RocketTargeting.cs
+++ b/Source/KerbalCombatSystems/RocketTargeting.cs
@@ -256,7 +256,7 @@ namespace KerbalCombatSystems
 
         private void NextRocket()
         {
-            decouplers = FindDecouplerChildren(part.parent, "Default");
+            decouplers = FindDecouplerChildren(part.parent);
             if (decouplers.Count < 1)
             {
                 controller.canFire = false;

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -227,6 +227,7 @@ namespace KerbalCombatSystems
                 // make sure the decoupler designator exists and is the specified type
                 module = currentPart.GetComponent<ModuleDecouplerDesignate>();
                 if (module == null) continue;
+                //"" is shorthand for ignoring the type requirement and firing any decoupler
                 if (type != "" && module.decouplerDesignation != type) continue;
                 //strike any decouplers without any child parts
                 if (!currentPart.FindChildParts<Part>(true).ToList().Any()) continue;

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -212,11 +212,9 @@ namespace KerbalCombatSystems
             return ship;
         }
 
-        public static ModuleDecouplerDesignate FindDecoupler(Part origin, string type)
+        // Search up the part tree to find a separator.
+        public static ModuleDecouplerDesignate FindDecoupler(Part origin, string type = "Default")
         {
-            // method to search up the part tree to find a single decoupler
-            bool defaultCoupler = (type != "" || type != null || type != "Default");
-
             Part currentPart;
             Part nextPart = origin.parent;
             ModuleDecouplerDesignate module;
@@ -229,7 +227,7 @@ namespace KerbalCombatSystems
                 // make sure the decoupler designator exists and is the specified type
                 module = currentPart.GetComponent<ModuleDecouplerDesignate>();
                 if (module == null) continue;
-                if (module.decouplerDesignation != type && !defaultCoupler) continue;
+                if (type != "" && module.decouplerDesignation != type) continue;
                 //strike any decouplers without any child parts
                 if (!currentPart.FindChildParts<Part>(true).ToList().Any()) continue;
 
@@ -239,15 +237,12 @@ namespace KerbalCombatSystems
             return null;
         }
 
-        public static List<ModuleDecouplerDesignate> FindDecouplerChildren(Part root, string type)
+        // Search the children of a specified part for separators.
+        public static List<ModuleDecouplerDesignate> FindDecouplerChildren(Part root, string type = "Default")
         {
-            // method to search the children of a specified part for decoupler modules
-            bool defaultCoupler = (type != "" || type != null || type != "Default");
-
             List<Part> childParts = root.FindChildParts<Part>(true).ToList();
-            //check the parent itself
             childParts.Insert(0, root);
-            //spawn empty modules list to add to
+
             List<ModuleDecouplerDesignate> seperatorList = new List<ModuleDecouplerDesignate>();
             ModuleDecouplerDesignate module;
 
@@ -257,7 +252,7 @@ namespace KerbalCombatSystems
 
                 // make sure the decoupler designator exists and is the specified type
                 if (module == null) continue;
-                if (module.decouplerDesignation != type && !defaultCoupler) continue;
+                if (type != "" && module.decouplerDesignation != type) continue;
                 //strike any decouplers without any child parts
                 if (!currentPart.FindChildParts<Part>(true).ToList().Any()) continue;
 

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -48,12 +48,15 @@ namespace KerbalCombatSystems
             //The basic ModuleRCS is depreciated and doesn't work properly with multiple nozzle rcs parts
             List<ModuleRCSFX> RCS = v.FindPartModulesImplementing<ModuleRCSFX>();
 
-            return GetFireVector(engines, RCS, v.transform.position).magnitude;
+            return GetFireVector(v.transform.position, engines, RCS).magnitude;
         }
 
-        public static Vector3 GetFireVector(List<ModuleEngines> engines, List<ModuleRCSFX> RCS, Vector3 origin)
+        public static Vector3 GetFireVector(Vector3 origin, List<ModuleEngines> engines, List<ModuleRCSFX> RCS = null)
         {
             //method to get the mean thrust vector of a list of engines and throttle enabled RCS
+
+            if (RCS == null)
+                RCS = new List<ModuleRCSFX>();
 
             //start the expected movement vector at the first child of the decoupler
             Vector3 thrustVector = origin;
@@ -170,6 +173,7 @@ namespace KerbalCombatSystems
             GameObject tc = new GameObject("dynamic");
             Transform transform = tc.transform;
             transform.SetParent(commander.transform);
+            transform.position = commander.transform.position;
 
             // Create a new control point with the transform.
             ControlPoint dynamic = new ControlPoint("dynamic", "Dynamic", transform, Vector3.zero);

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -162,24 +162,25 @@ namespace KerbalCombatSystems
             //do nothing otherwise
         }
 
+        // Create and set a new control point for a command module (commander) pointing along a world space vector (direction).
+        // Uses: controlling missiles from the the average engine direction to allow for mistaken/unconventional probe core orientation.
         public static void AlignReference(ModuleCommand commander, Vector3 direction)
         {
-            //align a command modules point of reference with a given vector
-            ControlPoint control = commander.GetControlPoint("dynamic");
+            // Create a new transform named dynamic.
+            GameObject tc = new GameObject("dynamic");
+            Transform transform = tc.transform;
+            transform.SetParent(commander.transform);
+
+            // Create a new control point with the transform.
+            ControlPoint dynamic = new ControlPoint("dynamic", "Dynamic", transform, Vector3.zero);
+
+            // Orient the control point towards direction (finger) with perpendicular as the up vector (thumb).
+            Vector3 perpendicular = Vector3.ProjectOnPlane(commander.transform.forward, direction);
+            dynamic.transform.rotation = Quaternion.LookRotation(perpendicular, direction); // VAB orientation.
+
+            // Add the control point to the command module and set it as active.
+            commander.controlPoints.Add("dynamic", dynamic);
             commander.SetControlPoint("dynamic");
-
-            //check that one doesn't already exist
-            if (control == null)
-            {
-                //switch over to default as a backup
-                control = commander.GetControlPoint("_default");
-                commander.SetControlPoint("_default");
-            }
-
-            //generate a new vector to act as the upwards direction
-            Vector3 perpendicular = new Vector3(1f, 1f, -(direction.x + direction.y) / direction.z);
-            //rotate the control point to be inline with the direction with perpendicular acting as the second pin
-            control.transform.rotation = Quaternion.LookRotation(perpendicular, direction);
         }
 
         #endregion

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -169,27 +169,21 @@ namespace KerbalCombatSystems
         // Uses: controlling missiles from the the average engine direction to allow for mistaken/unconventional probe core orientation.
         public static void AlignReference(ModuleCommand commander, Vector3 direction)
         {
-            ControlPoint dynamic = commander.GetControlPoint("dynamic");
+            // Create a new transform named dynamic.
+            GameObject tc = new GameObject("dynamic");
+            Transform transform = tc.transform;
+            transform.SetParent(commander.transform);
+            transform.position = commander.transform.position;
 
-            if (dynamic == null)
-            {
-                // Create a new transform named dynamic.
-                GameObject tc = new GameObject("dynamic");
-                Transform transform = tc.transform;
-                transform.SetParent(commander.transform);
-                transform.position = commander.transform.position;
-
-                // Create a new control point with the transform.
-                dynamic = new ControlPoint("dynamic", "Dynamic", transform, Vector3.zero);
-
-                // Add the control point to the command module.
-                commander.controlPoints.Add("dynamic", dynamic);
-            }
+            // Create a new control point with the transform.
+            ControlPoint dynamic = new ControlPoint("dynamic", "Dynamic", transform, Vector3.zero);
 
             // Orient the control point towards direction (finger) with perpendicular as the up vector (thumb).
             Vector3 perpendicular = Vector3.ProjectOnPlane(commander.transform.forward, direction);
             dynamic.transform.rotation = Quaternion.LookRotation(perpendicular, direction); // VAB orientation.
 
+            // Add the control point to the command module and set it as active.
+            commander.controlPoints.Add("dynamic", dynamic);
             commander.SetControlPoint("dynamic");
         }
 
@@ -221,9 +215,6 @@ namespace KerbalCombatSystems
         // Search up the part tree to find a separator.
         public static ModuleDecouplerDesignate FindDecoupler(Part origin, string type = "Default")
         {
-            if (type == null)
-                type = "Default";
-
             Part currentPart;
             Part nextPart = origin.parent;
             ModuleDecouplerDesignate module;
@@ -250,9 +241,6 @@ namespace KerbalCombatSystems
         // Search the children of a specified part for separators.
         public static List<ModuleDecouplerDesignate> FindDecouplerChildren(Part root, string type = "Default")
         {
-            if (type == null)
-                type = "Default";
-
             List<Part> childParts = root.FindChildParts<Part>(true).ToList();
             childParts.Insert(0, root); //check the parent itself
 

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -241,7 +241,7 @@ namespace KerbalCombatSystems
         public static List<ModuleDecouplerDesignate> FindDecouplerChildren(Part root, string type = "Default")
         {
             List<Part> childParts = root.FindChildParts<Part>(true).ToList();
-            childParts.Insert(0, root);
+            childParts.Insert(0, root); //check the parent itself
 
             List<ModuleDecouplerDesignate> seperatorList = new List<ModuleDecouplerDesignate>();
             ModuleDecouplerDesignate module;

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -169,21 +169,27 @@ namespace KerbalCombatSystems
         // Uses: controlling missiles from the the average engine direction to allow for mistaken/unconventional probe core orientation.
         public static void AlignReference(ModuleCommand commander, Vector3 direction)
         {
-            // Create a new transform named dynamic.
-            GameObject tc = new GameObject("dynamic");
-            Transform transform = tc.transform;
-            transform.SetParent(commander.transform);
-            transform.position = commander.transform.position;
+            ControlPoint dynamic = commander.GetControlPoint("dynamic");
 
-            // Create a new control point with the transform.
-            ControlPoint dynamic = new ControlPoint("dynamic", "Dynamic", transform, Vector3.zero);
+            if (dynamic == null)
+            {
+                // Create a new transform named dynamic.
+                GameObject tc = new GameObject("dynamic");
+                Transform transform = tc.transform;
+                transform.SetParent(commander.transform);
+                transform.position = commander.transform.position;
+
+                // Create a new control point with the transform.
+                dynamic = new ControlPoint("dynamic", "Dynamic", transform, Vector3.zero);
+
+                // Add the control point to the command module.
+                commander.controlPoints.Add("dynamic", dynamic);
+            }
 
             // Orient the control point towards direction (finger) with perpendicular as the up vector (thumb).
             Vector3 perpendicular = Vector3.ProjectOnPlane(commander.transform.forward, direction);
             dynamic.transform.rotation = Quaternion.LookRotation(perpendicular, direction); // VAB orientation.
 
-            // Add the control point to the command module and set it as active.
-            commander.controlPoints.Add("dynamic", dynamic);
             commander.SetControlPoint("dynamic");
         }
 
@@ -215,6 +221,9 @@ namespace KerbalCombatSystems
         // Search up the part tree to find a separator.
         public static ModuleDecouplerDesignate FindDecoupler(Part origin, string type = "Default")
         {
+            if (type == null)
+                type = "Default";
+
             Part currentPart;
             Part nextPart = origin.parent;
             ModuleDecouplerDesignate module;
@@ -241,6 +250,9 @@ namespace KerbalCombatSystems
         // Search the children of a specified part for separators.
         public static List<ModuleDecouplerDesignate> FindDecouplerChildren(Part root, string type = "Default")
         {
+            if (type == null)
+                type = "Default";
+
             List<Part> childParts = root.FindChildParts<Part>(true).ToList();
             childParts.Insert(0, root); //check the parent itself
 

--- a/Source/KerbalCombatSystems/Utils.cs
+++ b/Source/KerbalCombatSystems/Utils.cs
@@ -252,6 +252,7 @@ namespace KerbalCombatSystems
 
                 // make sure the decoupler designator exists and is the specified type
                 if (module == null) continue;
+                //"" is shorthand for ignoring the type requirement and firing any decoupler
                 if (type != "" && module.decouplerDesignation != type) continue;
                 //strike any decouplers without any child parts
                 if (!currentPart.FindChildParts<Part>(true).ToList().Any()) continue;

--- a/Source/KerbalCombatSystems/WeaponController.cs
+++ b/Source/KerbalCombatSystems/WeaponController.cs
@@ -467,7 +467,7 @@ namespace KerbalCombatSystems
 
             if (decoupler == null)
             {
-                var module = KCS.FindDecoupler(part, "Weapon"); // todo: set to false later
+                var module = KCS.FindDecoupler(part, "Weapon");
                 if (module == null) return 1.0f;
                 decoupler = module.part;
             }
@@ -488,7 +488,7 @@ namespace KerbalCombatSystems
         private void CountChildDecouplers()
         {
             Part parent;
-            var decoupler = FindDecoupler(part, "Weapon"); // todo: set to false later
+            var decoupler = FindDecoupler(part, "Weapon");
 
             if (decoupler != null)
                 parent = decoupler.part;

--- a/Source/KerbalCombatSystems/WeaponController.cs
+++ b/Source/KerbalCombatSystems/WeaponController.cs
@@ -467,7 +467,7 @@ namespace KerbalCombatSystems
 
             if (decoupler == null)
             {
-                var module = KCS.FindDecoupler(part, "Weapon");
+                var module = FindDecoupler(part);
                 if (module == null) return 1.0f;
                 decoupler = module.part;
             }
@@ -481,14 +481,13 @@ namespace KerbalCombatSystems
                 totalMass = totalMass + part.mass + part.GetResourceMass();
             }
 
-            mass = totalMass;
-            return totalMass;
+            return mass = totalMass;
         }
 
         private void CountChildDecouplers()
         {
             Part parent;
-            var decoupler = FindDecoupler(part, "Weapon");
+            var decoupler = FindDecoupler(part);
 
             if (decoupler != null)
                 parent = decoupler.part;
@@ -502,7 +501,7 @@ namespace KerbalCombatSystems
         public float CalculateAcceleration(Part decoupler = null)
         {
             if (decoupler == null)
-                decoupler = FindDecoupler(part, "Weapon").part;
+                decoupler = FindDecoupler(part).part;
 
             var children = decoupler.FindChildParts<Part>(true).ToList();
 


### PR DESCRIPTION
- Create dynamic control points when needed.
- Calculate propulsion debug line once.
- Make RCS list optional in GetFireVector.
- Fix docking port separation.
- Separator spelling change.
- Simplify FindDecoupler params.
- Miscellaneous tweaks & comment changes.